### PR TITLE
wrap `curl.setopt: :$URL` in Retry block

### DIFF
--- a/lib/Pakku/Fetcher.rakumod
+++ b/lib/Pakku/Fetcher.rakumod
@@ -18,17 +18,22 @@ multi method fetch ( Str $src!, :$unlink = True, :$dst = tempdir :$unlink ) {
 
   my $download = $dst.IO.add( $URL.path.tail ).Str;
 
-  $!curl.setopt: URL => $URL.Str, :$download;
 
-  retry { $!curl.perform };
+  retry {
 
-  .extract: destpath => $dst for archive-read $download;
+    $!curl.setopt: URL => $URL.Str, :$download;
 
-  my $prefix = $dst.IO.dir.first: *.d;
+    $!curl.perform;
 
-  🤓 "FTC: ｢$prefix｣";
+    .extract: destpath => $dst for archive-read $download;
 
-  $prefix.IO;
+    my $prefix = $dst.IO.dir.first: *.d;
+
+    🤓 "FTC: ｢$prefix｣";
+
+    $prefix.IO;
+
+  }
 
 }
 


### PR DESCRIPTION
Looks like if `$curl.perform` failed the first time, retrying
`$curl.perform` without `$curl.setopt: :$URL, :$download` returns empty content.

This behavior happens only when downloading a file, it doesn't show with
`$curl.preform.content`

To be more precise, `download` opt need to be set every time `$curl.perform` is called;